### PR TITLE
Using WordPress's own jquery-ui-widget

### DIFF
--- a/wp_jq_multiselect/class.wpjqmultiselect.php
+++ b/wp_jq_multiselect/class.wpjqmultiselect.php
@@ -44,8 +44,7 @@ class WpJqMultiSelect
  
     public function enqueue_js()
 	{
-		wp_register_script('jquiwidget', path_join($this->_urls['js_url'], 'jquery.ui.widget.js') , array('jquery'));
-                wp_register_script('jqmultiselect', path_join($this->_urls['js_url'], 'ui.multiselect.js') , array('jquery', 'jquiwidget', 'jquery-ui-core'));
+                wp_register_script('jqmultiselect', path_join($this->_urls['js_url'], 'ui.multiselect.js') , array('jquery', 'jquery-ui-widget', 'jquery-ui-core'));
                 wp_register_script('bzwpmultiselect', path_join($this->_urls['js_url'], 'bzwp_multiselect.js') , array('jquery', 'jquery-ui-core', 'jqmultiselect'));
                 wp_enqueue_script('jqmultiselect');
 		wp_enqueue_script('bzwpmultiselect');


### PR DESCRIPTION
This fixes compatibility problems with a variety of plugins, since it results in the loading of a jquery-ui-widget lib that is some random version, and most other plugins simply load the one that comes with stock WordPress.
